### PR TITLE
fix: dont assign dependabot to pr.

### DIFF
--- a/.github/workflows/action-lint.yaml
+++ b/.github/workflows/action-lint.yaml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/auto-assign-pr.yaml
+++ b/.github/workflows/auto-assign-pr.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   add_assignees:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-add-assignees@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - メインブランチへのプルリクエスト時に、GitHub Actionsワークフローのリントチェックを追加しました。

- **Chores**
  - 自動アサインジョブに条件を追加し、GitHubのアクターが'dependabot[bot]'でない場合にのみ実行されるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->