### PR TITLE
feat: auto assign pr workflow runs without bot.

### DIFF
--- a/.github/actions/inspect-event-sender-bot-or-not/action.yaml
+++ b/.github/actions/inspect-event-sender-bot-or-not/action.yaml
@@ -1,0 +1,23 @@
+name: "Inspect event sender is bot or not"
+
+inputs:
+  github_event_payload:
+    description: "GitHub event payload"
+    required: true
+
+outputs:
+  is_bot:
+    description: "Is bot or not"
+    value: ${{ steps.inspect.outputs.IS_BOT }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: inspect
+      id: inspect
+      run: |
+        IS_BOT=$(echo "$GITHUB_EVENT_PAYLOAD" | jq -r '.sender.type == "Bot"')
+        echo "IS_BOT=$IS_BOT" >> $GITHUB_OUTPUT
+      shell: bash
+      env:
+        GITHUB_EVENT_PAYLOAD: ${{ inputs.github_event_payload }}

--- a/.github/actions/inspect-event-sender-bot-or-not/action.yaml
+++ b/.github/actions/inspect-event-sender-bot-or-not/action.yaml
@@ -16,7 +16,7 @@ runs:
     - name: inspect
       id: inspect
       run: |
-        IS_BOT=$(echo "$GITHUB_EVENT_PAYLOAD" | jq -r '.sender.type == "Bot"')
+        IS_BOT=$(echo "${GITHUB_EVENT_PAYLOAD:-{}}" | jq -r '.sender.type == "Bot"')
         echo "IS_BOT=$IS_BOT" >> $GITHUB_OUTPUT
       shell: bash
       env:

--- a/.github/workflows/auto-assign-pr.yaml
+++ b/.github/workflows/auto-assign-pr.yaml
@@ -6,13 +6,24 @@ on:
       - opened
       - reopened
 
-permissions:
-  pull-requests: write
-
 jobs:
-  add_assignees:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+  inspect_actor_is_bot:
     runs-on: ubuntu-latest
+    outputs:
+      is_bot: ${{ steps.actor_is_bot.outputs.is_bot }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/inspect-event-sender-bot-or-not
+        id: actor_is_bot
+        with:
+          github_event_payload: ${{ toJSON(github.event) }}
+
+  add_assignees:
+    needs: inspect_actor_is_bot
+    if: ${{ ! fromJSON(needs.inspect_actor_is_bot.outputs.is_bot) }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions-ecosystem/action-add-assignees@v1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - GitHub アクション「Inspect actor is bot or not」を追加しました。ユーザーがボットかどうかを判定します。
  - GitHub アクション「Inspect event sender is bot or not」を追加しました。イベント送信者がボットかどうかを判定します。

- **ワークフローの変更**
  - `auto-assign-pr.yaml` ワークフローを変更し、新しいジョブ `inspect_actor_is_bot` の出力に基づいて `add_assignees` ジョブを実行するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->